### PR TITLE
added "module" rendering option

### DIFF
--- a/paths2openscad-de.inx
+++ b/paths2openscad-de.inx
@@ -32,6 +32,9 @@
 
     <param type="boolean" name="stlpost" gui-text="STL Nachbearbeitung" xml:lang="de">false</param>
     <param type="description" name="stlpost_help" xml:lang="de">Starte beispielsweise einen 'slicer' nach der STL-Konvertierung. Siehe auch den Reiter Kommandos.</param>
+
+    <param name="stlmodule" type="boolean" _gui-text="Erzeuge ein Modul">false</param>
+    <_param name="stlmodule_help" type="description">Rendern Sie das Objekt nicht in der Scad-Datei, erstellen Sie eine für den Import geeignete Datei.</_param>
     <param type="description" name="spacer"><!-- --></param>
   </page>
 

--- a/paths2openscad.inx
+++ b/paths2openscad.inx
@@ -32,6 +32,9 @@
 
     <param name="stlpost" type="boolean" _gui-text="STL postprocessing">false</param>
     <_param name="stlpost_help" type="description">Start e.g. a slicer after converting to STL. See the Commands tab for details.</_param>
+
+    <param name="stlmodule" type="boolean" _gui-text="Only create module">false</param>
+    <_param name="stlmodule_help" type="description">Do not render the object in the scad file, create file suitable for import.</_param>
     <_param name="spacer" type="description"><!-- --></_param>
   </page>
 

--- a/paths2openscad.py
+++ b/paths2openscad.py
@@ -427,6 +427,10 @@ class OpenSCAD(inkex.Effect):
             '--stlpostcmd', dest='stlpostcmd', type='string', default=INX_STL_POSTPROCESSING, action='store',
             help='Command used for post processing an STL file (typically a slicer). You can use {NAME}.stl for the STL file.')
 
+        self.OptionParser.add_option(
+            '--stlmodule', dest='stlmodule', type='string', default='false', action='store',
+            help='Output configured to comment out final rendering line, to create a module file for import.')
+
         self.dpi = 90.0                # factored out for inkscape-0.92
         self.px_used = False           # raw px unit depends on correct dpi.
         self.cx = float(DEFAULT_WIDTH)  / 2.0
@@ -1254,7 +1258,10 @@ fudge = 0.1;
             self.f.write('    }\n  }\n')
 
             # The module that calls all the other ones.
-            self.f.write('}\n\n%s(height);\n' % (name))
+            if self.options.stlmodule == 'true':
+                self.f.write('}\n\n//%s(height);\n' % (name))
+            else:
+                self.f.write('}\n\n%s(height);\n' % (name))
             self.f.close()
 
         except IOError as e:


### PR DESCRIPTION
I frequently want to generate shapes that I will consume as imported modules, rather than entire objects. This helps keep all of the path data out of my main project file and lets me iterate changes more easily.